### PR TITLE
src: main: Start Tokio runtime required by Sampler

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ mod logger;
 mod recorder;
 mod server;
 
-fn main() {
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
     logger::init();
 
     features::system::start(std::time::Duration::from_secs(5));


### PR DESCRIPTION
## Summary
- `system::start` uses `tokio::spawn`, which panics without a Tokio 1.x runtime
- 0.7+ already had `#[tokio::main]`; the 0.6 Sampler backport kept sync `main`, so v0.6.4 crashes on startup
- Match the 0.7 wiring: `#[tokio::main(flavor = "multi_thread")] async fn main`

## Test plan
- [x] `cargo build`
- [x] Run binary briefly: logs `System actor started` and binds actix without panic
- [ ] CI green on `0.6`
- [ ] Tag/release v0.6.5 after merge (v0.6.4 is broken)
